### PR TITLE
Testcase for closures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: php
+php:
+  - '7.1'
+  - '7.2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: php
 php:
   - '7.1'
   - '7.2'
+
+install:
+  - composer install --prefer-dist

--- a/src/RulesServiceProvider.php
+++ b/src/RulesServiceProvider.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Egeniq\Laravel\Rules;
-
 
 use Illuminate\Support\ServiceProvider;
 

--- a/tests/RulesHelperTest.php
+++ b/tests/RulesHelperTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Egeniq\Laravel\Rules\Test;
-
 
 use Illuminate\Validation\Rule;
 use Orchestra\Testbench\TestCase;
@@ -28,13 +26,18 @@ class RulesHelperTest extends TestCase
     {
         $testRule = new TestRule();
 
-        $testClosure = function($attribute, $value, $fail) {
+        $this->assertEquals(
+            ['required', 'integer', $testRule, 'foobar'],
+            rules('required|integer', $testRule, 'foobar')
+        );
+    }
+
+    public function testSupportsClosureRules()
+    {
+        $testClosure = function ($attribute, $value, $fail) {
             return $fail($attribute.' is invalid.');
         };
 
-        $this->assertEquals(
-            ['required', 'integer', $testRule, 'foobar', $testClosure],
-            rules('required|integer', $testRule, 'foobar', $testClosure)
-        );
+        $this->assertEquals([$testClosure], rules($testClosure));
     }
 }

--- a/tests/RulesHelperTest.php
+++ b/tests/RulesHelperTest.php
@@ -27,9 +27,14 @@ class RulesHelperTest extends TestCase
     public function testRulesFunctionParsesCorrectly()
     {
         $testRule = new TestRule();
+
+        $testClosure = function($attribute, $value, $fail) {
+            return $fail($attribute.' is invalid.');
+        };
+
         $this->assertEquals(
-            ['required', 'integer', $testRule, 'foobar'],
-            rules('required|integer', $testRule, 'foobar')
+            ['required', 'integer', $testRule, 'foobar', $testClosure],
+            rules('required|integer', $testRule, 'foobar', $testClosure)
         );
     }
 }


### PR DESCRIPTION
Writing rules as closures is new in Laravel 5.6. This proves `laravel-rules` supports this by adding a test.